### PR TITLE
Update to PySide6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ resources_rc.py
 
 # Environment
 .vscode/
+.venv/
 venv/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,5 @@
 exclude plover_svg_layout_display/*_rc.py
+exclude plover_svg_layout_display/*_ui.py
+include plover_svg_layout_display/*.ui
+include plover_svg_layout_display/*.qrc
 recursive-include plover_svg_layout_display/resources *

--- a/plover_svg_layout_display/config_ui.py
+++ b/plover_svg_layout_display/config_ui.py
@@ -1,9 +1,9 @@
-from PyQt5.QtWidgets import (
+from PySide6.QtWidgets import (
     QDialog, QWidget, QLabel, QDialogButtonBox, QGridLayout,
     QGroupBox, QCheckBox, QVBoxLayout, QLineEdit, QScrollArea,
     QFileDialog, QPushButton, QSpinBox
 )
-from PyQt5.QtCore import Qt
+from PySide6.QtCore import Qt
 
 from plover_svg_layout_display.layout_config import (
     CONFIG_FILE_PARAMS, SYSTEM_NAME_PLACEHOLDER, SYSTEM_PREFIX, 

--- a/plover_svg_layout_display/layout_ui.py
+++ b/plover_svg_layout_display/layout_ui.py
@@ -5,6 +5,7 @@ from plover.engine import StenoEngine
 from plover.oslayer.config import PLUGINS_PLATFORM
 from plover.gui_qt.tool import Tool
 from plover.steno import Stroke
+from plover import log
 
 from PySide6.QtWidgets import QHBoxLayout, QGraphicsView
 from PySide6.QtGui import QAction
@@ -183,7 +184,8 @@ class SVGLayoutDisplayTool(Tool):
             
             self.convert_stroke = convert_stroke
 
-        except Exception:
+        except Exception as e:
+            log.error("loading Python script from %s failed: %s", py_path, e, exc_info=True)
             self.convert_stroke = None
 
     def reload_config(self) -> None:

--- a/plover_svg_layout_display/layout_ui.py
+++ b/plover_svg_layout_display/layout_ui.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Tuple, Union
+from typing import Callable, Tuple, Union
 
 from plover import system
 from plover.engine import StenoEngine
@@ -6,9 +6,10 @@ from plover.oslayer.config import PLUGINS_PLATFORM
 from plover.gui_qt.tool import Tool
 from plover.steno import Stroke
 
-from PyQt5.QtWidgets import QAction, QHBoxLayout, QGraphicsView
-from PyQt5.QtGui import QKeySequence, QMouseEvent, QColor
-from PyQt5.QtCore import Qt, QRect, QSettings
+from PySide6.QtWidgets import QHBoxLayout, QGraphicsView
+from PySide6.QtGui import QAction
+from PySide6.QtGui import QKeySequence, QMouseEvent
+from PySide6.QtCore import Qt, QRect, QSettings
 
 from plover_svg_layout_display.resources_rc import *
 from plover_svg_layout_display.config_ui import ConfigUI
@@ -18,14 +19,14 @@ from plover_svg_layout_display.qt_utils import load_qt_text
 
 
 STYLESHEET = "border:0px; background:transparent;"
-DEFAULT_SVG = ":/svgld/en_layout.svg"
+DEFAULT_SVG = ":/svgld/resources/en_layout.svg"
 DEFAULT_SCALE = 100
-DEFAULT_PY = ":/svgld/en_convert.py"
+DEFAULT_PY = ":/svgld/resources/en_convert.py"
 
 
 class SVGLayoutDisplayTool(Tool):
     TITLE = "SVG Layout Display"
-    ICON = ":/svgld/icon.svg"
+    ICON = ":/svgld/resources/icon.svg"
     ROLE = "svgld"
 
     def __init__(self, engine: StenoEngine) -> None:
@@ -89,11 +90,11 @@ class SVGLayoutDisplayTool(Tool):
                 settings.setValue(sys_name + "/" + key, value)
     
     def view_mouse_move(self, event: QMouseEvent) -> None:
-        if event.buttons() & Qt.LeftButton:
+        if event.buttons() & Qt.MouseButton.LeftButton:
             self.move(event.globalPos() - self.drag_position)
 
     def view_mouse_press(self, event: QMouseEvent) -> None:
-        if event.buttons() & Qt.LeftButton:
+        if event.buttons() & Qt.MouseButton.LeftButton:
             self.drag_position = event.globalPos() - self.frameGeometry().topLeft()
     
     def setup_actions(self) -> None:
@@ -135,8 +136,8 @@ class SVGLayoutDisplayTool(Tool):
         self.trans_view.setStyleSheet(STYLESHEET)
 
     def setup_layout(self) -> None:
-        self.setWindowFlags(self.windowFlags() | Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint)
-        self.setAttribute(Qt.WA_TranslucentBackground)
+        self.setWindowFlags(self.windowFlags() | Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnTopHint)
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
         self.setStyleSheet("QWidget#svgld {background:transparent;}")
 
         self.svg_widget = LayoutWidget()
@@ -152,13 +153,11 @@ class SVGLayoutDisplayTool(Tool):
         self.show()
 
     def on_config_changed(self, config: dict) -> None:
-        if "system_name" not in config:
+        new_sys_name = config.get("system_name")
+        if not new_sys_name or new_sys_name == self.system_name:
             return
-        
-        new_sys_name = config["system_name"]
-        if new_sys_name == self.system_name:
-            return
- 
+
+        self.system_name = new_sys_name
         self.reload_config()
     
     def on_settings(self) -> None:
@@ -184,7 +183,7 @@ class SVGLayoutDisplayTool(Tool):
             
             self.convert_stroke = convert_stroke
 
-        except:
+        except Exception:
             self.convert_stroke = None
 
     def reload_config(self) -> None:

--- a/plover_svg_layout_display/layout_ui.py
+++ b/plover_svg_layout_display/layout_ui.py
@@ -205,6 +205,8 @@ class SVGLayoutDisplayTool(Tool):
         elif self.system_name == "English Stenotype":
             self.svg_widget.load_svg(DEFAULT_SVG, DEFAULT_SCALE)
             self.load_py_script(DEFAULT_PY)
+        else:
+            log.error("No configuration found for system name: %s", self.system_name)
         
         self.on_stroke(tuple())
 

--- a/plover_svg_layout_display/qt_utils.py
+++ b/plover_svg_layout_display/qt_utils.py
@@ -1,3 +1,4 @@
+from plover import log
 from PySide6.QtCore import QFile, QIODevice, QTextStream
 
 
@@ -12,5 +13,6 @@ def load_qt_text(text_path: str) -> str:
             text = text_stream.readAll()
             file.close()
         return text
-    except Exception:
+    except Exception as e:
+        log.error("Failed to load Qt text from %s: %s", text_path, e, exc_info=True)
         return ""

--- a/plover_svg_layout_display/qt_utils.py
+++ b/plover_svg_layout_display/qt_utils.py
@@ -1,17 +1,16 @@
-from PyQt5.QtCore import QFile, QIODevice, QTextStream
+from PySide6.QtCore import QFile, QIODevice, QTextStream
 
 
 def load_qt_text(text_path: str) -> str:
     try:
         file = QFile(text_path)
         text = ""
-        if file.open(QIODevice.ReadOnly | QFile.Text):
+        if file.open(QIODevice.OpenModeFlag.ReadOnly | QFile.OpenModeFlag.Text):
             text_stream = QTextStream(file)
-            text_stream.setCodec("utf-8")
             text_stream.setAutoDetectUnicode(True)
 
             text = text_stream.readAll()
             file.close()
         return text
-    except:
+    except Exception:
         return ""

--- a/plover_svg_layout_display/resources.qrc
+++ b/plover_svg_layout_display/resources.qrc
@@ -1,0 +1,8 @@
+<RCC>
+  <qresource prefix="/svgld">
+    <file>resources/icon.svg</file>
+    <file>resources/en_convert.py</file>
+    <file>resources/en_layout.svg</file>
+    <file>resources/invalid.svg</file>
+  </qresource>
+</RCC>

--- a/plover_svg_layout_display/resources/resources.qrc
+++ b/plover_svg_layout_display/resources/resources.qrc
@@ -1,8 +1,0 @@
-<RCC>
-  <qresource prefix="/svgld">
-    <file>icon.svg</file>
-    <file>en_convert.py</file>
-    <file>en_layout.svg</file>
-    <file>invalid.svg</file>
-  </qresource>
-</RCC>

--- a/plover_svg_layout_display/svg_parser.py
+++ b/plover_svg_layout_display/svg_parser.py
@@ -1,5 +1,5 @@
 from typing import List, Dict
-from lxml import etree as ET
+import lxml.etree as ET
 
 from plover_svg_layout_display.qt_utils import load_qt_text
 from plover_svg_layout_display.resources_rc import *

--- a/plover_svg_layout_display/svg_widget.py
+++ b/plover_svg_layout_display/svg_widget.py
@@ -1,3 +1,4 @@
+from plover import log
 from PySide6.QtWidgets import QWidget
 from PySide6.QtCore import QByteArray, Qt, QRect, QPoint
 from PySide6.QtSvgWidgets import QSvgWidget
@@ -49,14 +50,15 @@ class LayoutWidget(QSvgWidget):
             scale_ratio = scale / 100
             new_size = self.renderer().defaultSize()
             new_size.scale(
-                int(new_size.width() * scale_ratio), 
-                int(new_size.height() * scale_ratio), 
+                int(new_size.width() * scale_ratio),
+                int(new_size.height() * scale_ratio),
                 Qt.AspectRatioMode.KeepAspectRatio
             )
-            
+
             self.resize(new_size)
             self.renderer().setViewBox(QRect(QPoint(0, 0), new_size))
             self.svg_size = new_size
             self.is_invalid = invalid
-        except Exception:
+        except Exception as e:
+            log.error("Failed to load SVG from %s: %s", path, e, exc_info=True)
             self.load_invalid(scale)

--- a/plover_svg_layout_display/svg_widget.py
+++ b/plover_svg_layout_display/svg_widget.py
@@ -1,6 +1,6 @@
-from PyQt5.QtWidgets import QWidget, QSizePolicy
-from PyQt5.QtCore import QByteArray, Qt, QRect, QPoint
-from PyQt5.QtSvg import QSvgWidget
+from PySide6.QtWidgets import QWidget
+from PySide6.QtCore import QByteArray, Qt, QRect, QPoint
+from PySide6.QtSvgWidgets import QSvgWidget
 
 from typing import List
 
@@ -16,10 +16,10 @@ class LayoutWidget(QSvgWidget):
         super().__init__(parent)
 
         self.setObjectName("layout_widget")
-        self.setContextMenuPolicy(Qt.NoContextMenu)
+        self.setContextMenuPolicy(Qt.ContextMenuPolicy.NoContextMenu)
         self.setContentsMargins(0, 0, 0, 0)
         self.setStyleSheet("border:0px; background:transparent;")
-        self.renderer().setAspectRatioMode(Qt.KeepAspectRatio)
+        self.renderer().setAspectRatioMode(Qt.AspectRatioMode.KeepAspectRatio)
         self.is_invalid = False
         self.svg_size = None
 
@@ -51,12 +51,12 @@ class LayoutWidget(QSvgWidget):
             new_size.scale(
                 int(new_size.width() * scale_ratio), 
                 int(new_size.height() * scale_ratio), 
-                Qt.KeepAspectRatio
+                Qt.AspectRatioMode.KeepAspectRatio
             )
             
             self.resize(new_size)
             self.renderer().setViewBox(QRect(QPoint(0, 0), new_size))
             self.svg_size = new_size
             self.is_invalid = invalid
-        except:
+        except Exception:
             self.load_invalid(scale)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-	"plover[gui_qt]>=4.0.0.dev10",
-	"setuptools>=38.2.4",
+	"plover[gui_qt]>=5.0.0.dev3",
+	"setuptools>=79.0.0",
 	"wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = plover-svg-layout-display
-version = 0.0.7
+version = 1.0.0
 description = SVG-based layout display plugin for Plover
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -8,6 +8,7 @@ author = Kaoffie
 author_email = kaoffie@gmail.com
 url = https://github.com/Kaoffie/plover_svg_layout_display
 license = MIT License (MIT)
+license_file = LICENSE.txt
 classifiers = 
     Development Status :: 4 - Beta
     Environment :: Plugins
@@ -21,8 +22,8 @@ keywords = plover plover_plugin
 [options]
 zip_safe = True
 install_requires =
-    plover >= 4.0.0.dev10
-    lxml >= 4.9.0
+    plover >= 5.0.0.dev3
+    lxml >= 6.0.0
 packages = 
     plover_svg_layout_display
 


### PR DESCRIPTION
Migrating to PySide6 to support Plover v5.

Also adds error logging in case of exceptions and if no matching system_name was found.

An easy way to install this plugin in Plover v5 is via the GIT button in the Plugins Manager (next to the Install/Update button) using the URL https://github.com/mkrnr/plover_svg_layout_display@pyside6-migration

Feel free to edit this PR.